### PR TITLE
Create rocketSlice and add to main store

### DIFF
--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  rockets: [],
+};
+
+const rocketsSlice = createSlice({
+  name: 'rockets',
+  initialState,
+  reducers: {
+    setRockets(state, { payload }) {
+      return {
+        ...state,
+        rockets: payload,
+      };
+    },
+  },
+});
+
+export const { setRockets } = rocketsSlice.actions;
+export default rocketsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,9 @@
 import { configureStore } from '@reduxjs/toolkit';
+import rocketsReducer from './rockets/rocketsSlice';
 
 const store = configureStore({
   reducer: {
+    rockets: rocketsReducer,
   },
 });
 


### PR DESCRIPTION
### Rockets Milestone I: Create rocketSlice and add to main store

In this PR I did the following steps: 
- Created a new directory for all Rockets `Redux` state slice files.
- Create `RocketsSlice` with an empty initial state
- Create an essential `getRockets` reducer
- Add reducer to the main store