### PR TITLE
Add Basic Structure for Missions

### DIFF
--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  missions: [],
+};
+
+const missionsSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {
+    setMissions(state, { payload }) {
+      return {
+        ...state,
+        missions: payload,
+      };
+    },
+  },
+});
+
+export const { setMissions } = missionsSlice.actions;
+export default missionsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import rocketsReducer from './rockets/rocketsSlice';
+import missionsReducer from './missions/missionSlice';
 
 const store = configureStore({
   reducer: {
     rockets: rocketsReducer,
+    missions: missionsReducer,
   },
 });
 


### PR DESCRIPTION
Rockets Milestone I: Create MissionsSlice and add it to the main store
In this PR I did the following steps:

Created a new directory for all Missions Redux state slice files.
Create MissionsSlice with an empty initial state
Create an essential getMissions reducer
Add reducer to the main store