### PR TITLE
Display rockets - Lists render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.3.4",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.3.4",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -17,7 +17,7 @@ function Rocket({ flickrImages, name, description }) {
 }
 
 Rocket.propTypes = {
-  flickrImages: PropTypes.arrayOf(Array).isRequired,
+  flickrImages: PropTypes.instanceOf(Array).isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
 };

--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types';
+import styles from '../styles/Rocket.module.css';
 
 function Rocket({ flickrImages, name, description }) {
   return (
-    <article>
-      <div>
+    <article className={styles.rocketContainer}>
+      <div className={styles.rocketPicture}>
         <img src={flickrImages[0]} alt={name} />
       </div>
-      <div>
+      <div className={styles.rocketContent}>
         <h2>{name}</h2>
         <p>{description}</p>
         <button type="button">Reserve Rocket</button>
@@ -16,7 +17,7 @@ function Rocket({ flickrImages, name, description }) {
 }
 
 Rocket.propTypes = {
-  flickrImages: PropTypes.arrayOf([]).isRequired,
+  flickrImages: PropTypes.arrayOf(Array).isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
 };

--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+function Rocket({ flickrImages, name, description }) {
+  return (
+    <article>
+      <div>
+        <img src={flickrImages[0]} alt={name} />
+      </div>
+      <div>
+        <h2>{name}</h2>
+        <p>{description}</p>
+        <button type="button">Reserve Rocket</button>
+      </div>
+    </article>
+  );
+}
+
+Rocket.propTypes = {
+  flickrImages: PropTypes.arrayOf([]).isRequired,
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+export default Rocket;

--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -1,7 +1,20 @@
+import { useSelector } from 'react-redux';
+import Rocket from './Rocket';
+
 function Rockets() {
+  const { rockets } = useSelector((state) => state.rockets);
+
   return (
     <section>
-      Rockets
+      <ul>
+        {
+          rockets.map((rocket) => (
+            <li key={rocket.id}>
+              <Rocket flickrImages={rocket.flickr_images} name={rocket.name} description={rocket.description} />
+            </li>
+          ))
+        }
+      </ul>
     </section>
   );
 }

--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -1,16 +1,21 @@
 import { useSelector } from 'react-redux';
 import Rocket from './Rocket';
+import styles from '../styles/Rockets.module.css';
 
 function Rockets() {
   const { rockets } = useSelector((state) => state.rockets);
 
   return (
-    <section>
-      <ul>
+    <section className={styles.rocketsContainer}>
+      <ul className={styles.rocketList}>
         {
           rockets.map((rocket) => (
             <li key={rocket.id}>
-              <Rocket flickrImages={rocket.flickr_images} name={rocket.name} description={rocket.description} />
+              <Rocket
+                flickrImages={rocket.flickr_images}
+                name={rocket.name}
+                description={rocket.description}
+              />
             </li>
           ))
         }

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -7,7 +7,18 @@ const initialState = {
 
 export const getRockets = createAsyncThunk(
   'rockets/getRockets',
-  () => axios.get('https://api.spacexdata.com/v3/rockets'),
+  async () => {
+    const response = await axios.get('https://api.spacexdata.com/v3/rockets');
+    return response.data.map(
+      (rocket) => ({
+        id: rocket.rocket_id,
+        name: rocket.rocket_name,
+        type: rocket.rocket_type,
+        flickr_images: rocket.flickr_images,
+        description: rocket.description,
+      }),
+    );
+  },
 );
 
 const rocketsSlice = createSlice({
@@ -17,20 +28,7 @@ const rocketsSlice = createSlice({
     setRockets: (state, { payload }) => ({ ...state, rockets: payload }),
   },
   extraReducers: (builder) => {
-    builder.addCase(getRockets.fulfilled, (state, { payload }) => (
-      {
-        ...state,
-        rockets: payload.data.map(
-          (rocket) => ({
-            id: rocket.rocket_id,
-            name: rocket.rocket_name,
-            type: rocket.rocket_type,
-            flickr_images: rocket.flickr_images,
-            description: rocket.description,
-          }),
-        ),
-      }
-    ));
+    builder.addCase(getRockets.fulfilled, (state, { payload }) => ({ ...state, rockets: payload }));
   },
 });
 

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -26,6 +26,7 @@ const rocketsSlice = createSlice({
             name: rocket.rocket_name,
             type: rocket.rocket_type,
             flickr_images: rocket.flickr_images,
+            description: rocket.description,
           }),
         ),
       }

--- a/src/styles/Rocket.module.css
+++ b/src/styles/Rocket.module.css
@@ -1,0 +1,36 @@
+.rocketContainer {
+  display: flex;
+  gap: 20px;
+}
+
+.rocketPicture {
+  width: 200px;
+}
+
+.rocketPicture > img {
+  width: 200px;
+}
+
+.rocketContent {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.rocketContent > h2 {
+  font-size: 20px;
+}
+
+.rocketContent > p {
+  font-size: 14px;
+}
+
+.rocketContent > button {
+  align-self: flex-start;
+  border: none;
+  background-color: #3f6ad8;
+  padding: 10px;
+  border-radius: 5px;
+  color: white;
+  cursor: pointer;
+}

--- a/src/styles/Rockets.module.css
+++ b/src/styles/Rockets.module.css
@@ -1,0 +1,12 @@
+.rocketsContainer {
+  padding: 20px 70px;
+}
+
+.rocketList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}


### PR DESCRIPTION
### Display rockets - Lists render

In this PR I completed next steps:

- Use `useSelector()` Redux Hook to select the state slices and render lists of rockets in corresponding routes.
- Style the whole application "by hand".
- Render a list of rockets (as per design). For the image of a rocket using the first image in the array of `flickr_images`.
