### PR TITLE
Implement rocket booking cancelation - Actions

### DIFF
--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { bookRocket } from '../redux/rockets/rocketsSlice';
+import { bookRocket, cancelBookRocket } from '../redux/rockets/rocketsSlice';
 import styles from '../styles/Rocket.module.css';
 
 function Rocket({
@@ -8,8 +8,12 @@ function Rocket({
 }) {
   const dispatch = useDispatch();
 
-  const clickHandler = () => {
+  const reserveClickHandler = () => {
     dispatch(bookRocket(id));
+  };
+
+  const cancelationClickHandler = () => {
+    dispatch(cancelBookRocket(id));
   };
 
   return (
@@ -23,7 +27,13 @@ function Rocket({
           { reserved && <span className={styles.reservedLabel}>Reserved</span> }
           {description}
         </p>
-        <button type="button" onClick={clickHandler}>Reserve Rocket</button>
+        { !reserved && <button type="button" onClick={reserveClickHandler}>Reserve Rocket</button> }
+        { reserved
+          && (
+          <button type="button" onClick={cancelationClickHandler} className={styles.cancel}>
+            Cancel Reservation
+          </button>
+          )}
       </div>
     </article>
   );

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -36,11 +36,22 @@ const rocketsSlice = createSlice({
         rockets: newRockets,
       };
     },
+    cancelBookRocket: (state, { payload }) => {
+      const newRockets = state.rockets.map((rocket) => {
+        if (rocket.id !== payload) { return rocket; }
+        return { ...rocket, reserved: false };
+      });
+
+      return {
+        ...state,
+        rockets: newRockets,
+      };
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(getRockets.fulfilled, (state, { payload }) => ({ ...state, rockets: payload }));
   },
 });
 
-export const { bookRocket } = rocketsSlice.actions;
+export const { bookRocket, cancelBookRocket } = rocketsSlice.actions;
 export default rocketsSlice.reducer;

--- a/src/styles/Rocket.module.css
+++ b/src/styles/Rocket.module.css
@@ -35,6 +35,12 @@
   cursor: pointer;
 }
 
+.rocketContent > button.cancel {
+  background-color: white;
+  border: 1px solid gray;
+  color: gray;
+}
+
 .reservedLabel {
   background-color: rgb(44, 167, 171);
   color: white;


### PR DESCRIPTION
### Implement rocket booking cancelation - Actions
In this PR I complete next steps:

- Using the same logic as with the "Reserve rocket" but set `reserved` key to `false`. 
- Actions are dispatched upon clicking on the corresponding buttons.