### PR TITLE
Switch badges for Rockets - Conditional components

### DIFF
--- a/src/styles/Rocket.module.css
+++ b/src/styles/Rocket.module.css
@@ -42,7 +42,7 @@
 }
 
 .reservedLabel {
-  background-color: rgb(44, 167, 171);
+  background-color: rgb(45, 191, 196);
   color: white;
   padding: 1px 5px;
   border-radius: 2px;


### PR DESCRIPTION
### Switch badges for Rockets - Conditional components

Rockets that have already been reserved show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket".