### PR TITLE
Switch badges for Missions

### DIFF
--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -20,7 +20,14 @@ function Mission({
       <td>{name}</td>
       <td>{description}</td>
       <td>
-        <span>NOT A MEMBER</span>
+        {
+          !reserved
+          && <span>NOT A MEMBER</span>
+        }
+        {
+          reserved
+          && <span>Active Member</span>
+        }
       </td>
       <td>
         {


### PR DESCRIPTION
Rockets Milestone 6: Switch badges for Missions
In this PR I did the following steps:

Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).